### PR TITLE
Fix orphaned SparkFun-KiCad-Libraries gitlinks in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,14 @@
 	path = VLCModule
 	url = https://github.com/open3doled/VLCModule.git
 	branch = main
+[submodule "3DIREmitterHardware/v2.1b/footprints/SparkFun-KiCad-Libraries"]
+	path = 3DIREmitterHardware/v2.1b/footprints/SparkFun-KiCad-Libraries
+	url = https://github.com/sparkfun/SparkFun-KiCad-Libraries.git
+
+[submodule "3DIREmitterHardware/v2.2b/microcontroller_board/footprints/SparkFun-KiCad-Libraries"]
+	path = 3DIREmitterHardware/v2.2b/microcontroller_board/footprints/SparkFun-KiCad-Libraries
+	url = https://github.com/sparkfun/SparkFun-KiCad-Libraries.git
+
+[submodule "3DIREmitterHardware/v2.2b/sensor_emitter_board/footprints/SparkFun-KiCad-Libraries"]
+	path = 3DIREmitterHardware/v2.2b/sensor_emitter_board/footprints/SparkFun-KiCad-Libraries
+	url = https://github.com/sparkfun/SparkFun-KiCad-Libraries.git


### PR DESCRIPTION
… gitlinks

Three submodule gitlinks existed in the tree without corresponding .gitmodules entries, causing 'git submodule status --recursive' and 'git submodule update --init --recursive' to fail with 'no submodule mapping found' after the outer repo cloned successfully:

  - 3DIREmitterHardware/v2.1b/footprints/SparkFun-KiCad-Libraries
  - 3DIREmitterHardware/v2.2b/microcontroller_board/footprints/SparkFun-KiCad-Libraries
  - 3DIREmitterHardware/v2.2b/sensor_emitter_board/footprints/SparkFun-KiCad-Libraries

All three point at github.com/sparkfun/SparkFun-KiCad-Libraries at the already-pinned commit (6d1f759).